### PR TITLE
fix(input): Fix input params

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Test
+        run: npm run format:check

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { generateNotes: gn } = require("./src/release-notes-generator");
 const { validateStrategy, getStrategies } = require("./src/utils");
 
 const analyzeCommits = async (pluginConfig, context) => {
-  const { commitAnalyzerConfig, strategy: inputStrategy } = pluginConfig;
+  const { commitAnalyzerConfig, strategy: inputStrategy } = pluginConfig || {};
   const strategy = validateStrategy(inputStrategy);
   if (!strategy) {
     throw new Error(
@@ -17,7 +17,7 @@ const analyzeCommits = async (pluginConfig, context) => {
 };
 
 const generateNotes = async (pluginConfig, context) => {
-  const { notesGeneratorConfig, strategy: inputStrategy } = pluginConfig;
+  const { notesGeneratorConfig, strategy: inputStrategy } = pluginConfig || {};
   const strategy = validateStrategy(inputStrategy);
   if (!strategy) {
     throw new Error(

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "repository": {
     "type": "git",

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,0 +1,35 @@
+const { analyzeCommits, generateNotes } = require("..");
+const ac = require("./commit-analyzer").analyzeCommits;
+const gn = require("./release-notes-generator").generateNotes;
+
+jest.mock("./commit-analyzer", () => ({
+  analyzeCommits: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock("./release-notes-generator", () => ({
+  generateNotes: jest.fn().mockResolvedValue(),
+}));
+
+describe("analyzeCommits", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("works when there is no plugin config specified, defaults to github strategy", () => {
+    return analyzeCommits().then(() => {
+      expect(ac).toBeCalledWith("github", undefined, undefined);
+    });
+  });
+});
+
+describe("generateNotes", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("works when there is no plugin config specified, defaults to github strategy", () => {
+    return generateNotes().then(() => {
+      expect(gn).toBeCalledWith("github", undefined, undefined);
+    });
+  });
+});


### PR DESCRIPTION
Nothing to destruct when we did not specify plugin configuration in the
semantic-release config file. We make sure to destruct
something that exists