### PR TITLE
feat(strategy): Introduce strict-github strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ You can read more about this in the official
 This plugin hijacks semantic-release flow and replaces the commits list with the one that respects these rules
 into the mix.
 
+### Strict GitHub strategy (`{strategy: 'strict-github'}`)
+
+The same as the **_GitHub strategy_**, but it will throw an error if the first commit title is not equal
+to the pull request title.
+
 ### Pull Request strategy (`{strategy: 'pull-request'}`)
 
 Always analyzes the pull request title and description as a commit.

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -29,7 +29,7 @@ describe("analyzeCommits", () => {
       },
       (err) => {
         expect(err.message).toBe(
-          "Invalid strategy: foo. Available options: github, pull-request, strict-pull-request"
+          "Invalid strategy: foo. Available options: github, strict-github, pull-request, strict-pull-request"
         );
       }
     );
@@ -76,7 +76,7 @@ describe("generateNotes", () => {
       },
       (err) => {
         expect(err.message).toBe(
-          "Invalid strategy: foo. Available options: github, pull-request, strict-pull-request"
+          "Invalid strategy: foo. Available options: github, strict-github, pull-request, strict-pull-request"
         );
       }
     );


### PR DESCRIPTION
This strategy is equal to the GitHub strategy except it will throw
an error if the first commit title is not equal to the pull request
title. Regarding the GitHub flow, the squash commit title depends on
the number of the commit messages in the feature branch. This strict
mode makes the behavior consistent and ensures the title represent
actual squash commit info