### PR TITLE
fix(commits): First commit is actually last commit

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,6 +36,8 @@ const mergeItems = (arr) => arr.join("\n\n");
 const getFullCommit = (title, body) =>
   mergeItems([title, body].filter(Boolean));
 
+const getFirstCommit = (commits) => commits[commits.length - 1];
+
 const imitateCommit = (title, body) => ({
   subject: title,
   body,
@@ -58,15 +60,20 @@ const getPullRequestAsCommit = async () => {
   return imitateCommit(title, body);
 };
 
+const getGithubStrategyCommitBody = (commits) =>
+  mergeItems(
+    commits
+      .map(({ subject: t, body: b }) => getFullCommit(`* ${t}`, b))
+      .reverse()
+  );
+
 const getGithubStrategyCommit = async (commits, prCommit) => {
   if (commits.length === 1) {
-    return commits[0];
+    return getFirstCommit(commits);
   }
 
   const { subject } = prCommit || (await getPullRequestAsCommit());
-  const body = mergeItems(
-    commits.map(({ subject: t, body: b }) => getFullCommit(`* ${t}`, b))
-  );
+  const body = getGithubStrategyCommitBody(commits);
 
   return imitateCommit(subject, body);
 };
@@ -77,7 +84,7 @@ const getStrictGithubStrategyCommit = async (commits) => {
   }
 
   const prCommit = await getPullRequestAsCommit();
-  const firstCommit = commits[0];
+  const firstCommit = getFirstCommit(commits);
 
   if (eqSubject(prCommit, firstCommit)) {
     return getGithubStrategyCommit(commits, prCommit);
@@ -94,7 +101,7 @@ const getStrictPullRequestStrategyCommit = async (commits) => {
   }
 
   const prCommit = await getPullRequestAsCommit();
-  const firstCommit = commits[0];
+  const firstCommit = getFirstCommit(commits);
   if (eqFull(prCommit, firstCommit)) {
     return prCommit;
   }

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -83,14 +83,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 
@@ -121,14 +121,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 
@@ -184,14 +184,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 
@@ -247,14 +247,14 @@ describe("utils", () => {
 
           const commits = [
             {
-              subject: "Commit title 1",
-              body: "description 1",
-              message: "Commit title 1\n\ndescription 1",
-            },
-            {
               subject: "Commit title 2",
               body: "description 2",
               message: "Commit title 2\n\ndescription 2",
+            },
+            {
+              subject: "Commit title 1",
+              body: "description 1",
+              message: "Commit title 1\n\ndescription 1",
             },
           ];
 
@@ -309,14 +309,14 @@ describe("utils", () => {
 
           const commits = [
             {
-              subject: "Commit title 1",
-              body: "description 1",
-              message: "Commit title 1\n\ndescription 1",
-            },
-            {
               subject: "Commit title 2",
               body: "description 2",
               message: "Commit title 2\n\ndescription 2",
+            },
+            {
+              subject: "Commit title 1",
+              body: "description 1",
+              message: "Commit title 1\n\ndescription 1",
             },
           ];
 
@@ -382,14 +382,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 
@@ -419,14 +419,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 
@@ -506,14 +506,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 
@@ -543,14 +543,14 @@ describe("utils", () => {
 
         const commits = [
           {
-            subject: "Commit title 1",
-            body: "description 1",
-            message: "Commit title 1\n\ndescription 1",
-          },
-          {
             subject: "Commit title 2",
             body: "description 2",
             message: "Commit title 2\n\ndescription 2",
+          },
+          {
+            subject: "Commit title 1",
+            body: "description 1",
+            message: "Commit title 1\n\ndescription 1",
           },
         ];
 


### PR DESCRIPTION
In the history of semantic-release commits list, the first commit
is actually the last one. So I reverse the order where I iterate
over the commits list